### PR TITLE
Add ListShare entity for shopping list sharing

### DIFF
--- a/src/nimblist/Nimblist.test/Controllers/ShoppingListsControllerTests.cs
+++ b/src/nimblist/Nimblist.test/Controllers/ShoppingListsControllerTests.cs
@@ -36,11 +36,11 @@ namespace Nimblist.test.Controllers
         }
 
         // Helper method to seed data into a fresh context instance
-        private async Task SeedDataAsync(params ShoppingList[] shoppingLists)
+        private async Task SeedDataAsync(params object[] entities)
         {
             using (var context = new NimblistContext(_dbOptions))
             {
-                context.ShoppingLists.AddRange(shoppingLists);
+                context.AddRange(entities);
                 await context.SaveChangesAsync();
             }
         }
@@ -76,6 +76,8 @@ namespace Nimblist.test.Controllers
                 new ShoppingList { Id = userListId, Name = "My Test List", UserId = TestUserId },
                 new ShoppingList { Id = otherUserListId, Name = "Other User's List", UserId = otherUserId }
             );
+
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = userListId, UserId = TestUserId });
 
             using (var context = new NimblistContext(_dbOptions))
             {
@@ -141,6 +143,7 @@ namespace Nimblist.test.Controllers
             // Arrange
             var listId = Guid.NewGuid();
             await SeedDataAsync(new ShoppingList { Id = listId, Name = "My Specific List", UserId = TestUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = listId, UserId = TestUserId });
 
             using (var context = new NimblistContext(_dbOptions))
             {
@@ -197,6 +200,7 @@ namespace Nimblist.test.Controllers
             // Arrange
             var listIdToDelete = Guid.NewGuid();
             await SeedDataAsync(new ShoppingList { Id = listIdToDelete, Name = "List To Delete", UserId = TestUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = listIdToDelete, UserId = TestUserId });
 
             using (var context = new NimblistContext(_dbOptions)) // Context for Act
             {
@@ -274,6 +278,7 @@ namespace Nimblist.test.Controllers
             var updatedName = "Updated List Name";
 
             await SeedDataAsync(new ShoppingList { Id = listId, Name = initialName, UserId = TestUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = listId, UserId = TestUserId });
 
             using (var context = new NimblistContext(_dbOptions))
             {
@@ -370,20 +375,15 @@ namespace Nimblist.test.Controllers
 
             await SeedDataAsync(
                 new ShoppingList { Id = ownedListId, Name = "Owned List", UserId = userId },
-                new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId, IsShared = true }
+                new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId }
             );
 
-            var family = new Family { Id = Guid.NewGuid(), Name = "Family" };
-            var familyMember = new FamilyMember { Id = Guid.NewGuid(), FamilyId = family.Id, UserId = userId };
-            var otherFamilyMember = new FamilyMember { Id = Guid.NewGuid(), FamilyId = family.Id, UserId = sharedUserId };
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = ownedListId, UserId = TestUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = sharedListId, UserId = TestUserId });
+
 
             using (var context = new NimblistContext(_dbOptions))
             {
-                context.Families.Add(family);
-                context.FamilyMembers.Add(familyMember);
-                context.FamilyMembers.Add(otherFamilyMember);
-                await context.SaveChangesAsync();
-
                 var controller = CreateControllerWithContext(context);
 
                 // Act
@@ -403,19 +403,12 @@ namespace Nimblist.test.Controllers
             // Arrange
             var sharedUserId = "shared-user-id";
             var sharedListId = Guid.NewGuid();
-            await SeedDataAsync(new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId, IsShared = true });
-
-            var family = new Family { Id = Guid.NewGuid(), Name = "Family" };
-            var familyMember = new FamilyMember { Id = Guid.NewGuid(), FamilyId = family.Id, UserId = TestUserId };
-            var otherFamilyMember = new FamilyMember { Id = Guid.NewGuid(), FamilyId = family.Id, UserId = sharedUserId };
+            await SeedDataAsync(new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = sharedListId, UserId = TestUserId });
+            await SeedDataAsync(new ListShare { Id = Guid.NewGuid(), ListId = sharedListId, UserId = sharedUserId });
 
             using (var context = new NimblistContext(_dbOptions))
             {
-                context.Families.Add(family);
-                context.FamilyMembers.Add(familyMember);
-                context.FamilyMembers.Add(otherFamilyMember);
-                await context.SaveChangesAsync();
-
                 var controller = CreateControllerWithContext(context);
 
                 // Act
@@ -433,7 +426,7 @@ namespace Nimblist.test.Controllers
             // Arrange
             var sharedUserId = "shared-user-id";
             var sharedListId = Guid.NewGuid();
-            await SeedDataAsync(new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId, IsShared = true });
+            await SeedDataAsync(new ShoppingList { Id = sharedListId, Name = "Shared List", UserId = sharedUserId });
 
             using (var context = new NimblistContext(_dbOptions))
             {

--- a/src/nimblist/nimblist.data/Migrations/20250415080754_ListSharing.Designer.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415080754_ListSharing.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nimblist.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nimblist.data.Migrations
 {
     [DbContext(typeof(NimblistContext))]
-    partial class NimblistContextModelSnapshot : ModelSnapshot
+    [Migration("20250415080754_ListSharing")]
+    partial class ListSharing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -342,6 +345,9 @@ namespace Nimblist.data.Migrations
 
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<bool>("IsShared")
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Name")
                         .IsRequired()

--- a/src/nimblist/nimblist.data/Migrations/20250415080754_ListSharing.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415080754_ListSharing.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nimblist.data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ListSharing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UserId",
+                table: "Families",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "ListShares",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    FamilyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ListId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SharedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ListShares", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ListShares_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ListShares_Families_FamilyId",
+                        column: x => x.FamilyId,
+                        principalTable: "Families",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ListShares_ShoppingLists_ListId",
+                        column: x => x.ListId,
+                        principalTable: "ShoppingLists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListShares_FamilyId",
+                table: "ListShares",
+                column: "FamilyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListShares_ListId",
+                table: "ListShares",
+                column: "ListId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListShares_UserId",
+                table: "ListShares",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ListShares");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "Families");
+        }
+    }
+}

--- a/src/nimblist/nimblist.data/Migrations/20250415085401_ListSharing-RemFlag.Designer.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415085401_ListSharing-RemFlag.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nimblist.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nimblist.data.Migrations
 {
     [DbContext(typeof(NimblistContext))]
-    partial class NimblistContextModelSnapshot : ModelSnapshot
+    [Migration("20250415085401_ListSharing-RemFlag")]
+    partial class ListSharingRemFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/nimblist/nimblist.data/Migrations/20250415085401_ListSharing-RemFlag.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415085401_ListSharing-RemFlag.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nimblist.data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ListSharingRemFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsShared",
+                table: "ShoppingLists");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsShared",
+                table: "ShoppingLists",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/nimblist/nimblist.data/Models/ApplicationUser.cs
+++ b/src/nimblist/nimblist.data/Models/ApplicationUser.cs
@@ -14,5 +14,7 @@ namespace Nimblist.Data.Models
 
         // Navigation property for the many-to-many relationship with Family
         public virtual ICollection<FamilyMember> Families { get; set; } = new List<FamilyMember>();
+
+        public virtual ICollection<ListShare> ListShares { get; set; } = new List<ListShare>();
     }
 }

--- a/src/nimblist/nimblist.data/Models/Family.cs
+++ b/src/nimblist/nimblist.data/Models/Family.cs
@@ -12,7 +12,12 @@ namespace Nimblist.Data.Models
         [MaxLength(100)]
         public string Name { get; set; } = string.Empty;
 
+        [Required]
+        public string UserId { get; set; } = string.Empty;
+
         // Navigation property for the many-to-many relationship with ApplicationUser
         public virtual ICollection<FamilyMember> Members { get; set; } = new List<FamilyMember>();
+
+        public virtual ICollection<ListShare> ListShares { get; set; } = new List<ListShare>();
     }
 }

--- a/src/nimblist/nimblist.data/Models/ListShare.cs
+++ b/src/nimblist/nimblist.data/Models/ListShare.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Nimblist.Data.Models
+{
+    public class ListShare
+    {
+        [Key]
+        public Guid Id { get; set; }
+
+
+        public string UserId { get; set; } = string.Empty;
+
+
+        public Guid FamilyId { get; set; }
+        public Guid ListId { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public virtual ApplicationUser? User { get; set; }
+
+        [ForeignKey(nameof(FamilyId))]
+        public virtual Family? Family { get; set; }
+        [ForeignKey(nameof(ListId))]
+        public virtual ShoppingList? List { get; set; }
+
+        // When the user joined the family
+        public DateTimeOffset SharedAt { get; set; } = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/nimblist/nimblist.data/Models/ShoppingList.cs
+++ b/src/nimblist/nimblist.data/Models/ShoppingList.cs
@@ -21,8 +21,6 @@ namespace Nimblist.Data.Models
         [Required]
         public string UserId { get; set; } = string.Empty; // Foreign key property (matches IdentityUser's Id type - string)
 
-        public bool IsShared { get; set; } = false; // Indicates if the list is shared with family members
-
         // Navigation property back to the user who owns this list
         [ForeignKey(nameof(UserId))] // Links this navigation property to the UserId foreign key
         public virtual ApplicationUser? User { get; set; } // Reference to the related ApplicationUser
@@ -30,5 +28,7 @@ namespace Nimblist.Data.Models
         // --- Relationship with Item ---
         // Navigation property: A shopping list contains multiple items
         public virtual ICollection<Item> Items { get; set; } = new List<Item>(); // Initialize collection
+
+        public virtual ICollection<ListShare> ListShares { get; set; } = new List<ListShare>();
     }
 }

--- a/src/nimblist/nimblist.data/NimblistContext.cs
+++ b/src/nimblist/nimblist.data/NimblistContext.cs
@@ -15,6 +15,8 @@ namespace Nimblist.Data
         public virtual DbSet<Family> Families { get; set; }
         public virtual DbSet<FamilyMember> FamilyMembers { get; set; }
 
+        public virtual DbSet<ListShare> ListShares { get; set; } = null!; // Initialize to avoid null warnings
+
         // Constructor needed for dependency injection.
         // It accepts DbContextOptions, allowing the configuration (like connection string)
         // to be specified in your main API project (Program.cs).
@@ -80,6 +82,34 @@ namespace Nimblist.Data
                 .HasMany(u => u.Families)
                 .WithOne(m => m.User)
                 .HasForeignKey(m => m.UserId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Index for performance
+            builder.Entity<FamilyMember>()
+                .HasIndex(m => new { m.UserId, m.FamilyId })
+                .IsUnique()
+                .HasDatabaseName("IX_FamilyMembers_UserId_FamilyId");
+
+            builder.Entity<Family>()
+                .HasMany(f => f.ListShares)
+                .WithOne(m => m.Family)
+                .HasForeignKey(m => m.FamilyId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // ApplicationUser to FamilyMember relationship
+            builder.Entity<ApplicationUser>()
+                .HasMany(u => u.ListShares)
+                .WithOne(m => m.User)
+                .HasForeignKey(m => m.UserId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<ShoppingList>()
+                .HasMany(u => u.ListShares)
+                .WithOne(m => m.List)
+                .HasForeignKey(m => m.ListId)
                 .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
 


### PR DESCRIPTION
Add ListShare entity for shopping list sharing

This commit introduces a new `ListShare` entity to manage the many-to-many relationship between users and shopping lists, enabling list sharing with families. The `IsShared` property has been removed from the `ShoppingList` entity, and the database context has been updated to include a `DbSet<ListShare>`. Migration files have been created to add the `ListShare` table and remove the `IsShared` column. Test files have been updated to reflect the new functionality, and the `GetUserShoppingLists` method has been modified to retrieve both user-owned and shared shopping lists.