### PR TITLE
Update ListShare to allow nullable FamilyId and UserId

### DIFF
--- a/src/nimblist/nimblist.data/Migrations/20250415092901_ListSharing-Constraints.Designer.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415092901_ListSharing-Constraints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nimblist.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nimblist.data.Migrations
 {
     [DbContext(typeof(NimblistContext))]
-    partial class NimblistContextModelSnapshot : ModelSnapshot
+    [Migration("20250415092901_ListSharing-Constraints")]
+    partial class ListSharingConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -310,7 +313,7 @@ namespace Nimblist.data.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("FamilyId")
+                    b.Property<Guid>("FamilyId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("ListId")
@@ -320,6 +323,7 @@ namespace Nimblist.data.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("UserId")
+                        .IsRequired()
                         .HasColumnType("text");
 
                     b.HasKey("Id");
@@ -445,7 +449,8 @@ namespace Nimblist.data.Migrations
                     b.HasOne("Nimblist.Data.Models.Family", "Family")
                         .WithMany("ListShares")
                         .HasForeignKey("FamilyId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.HasOne("Nimblist.Data.Models.ShoppingList", "List")
                         .WithMany("ListShares")
@@ -456,7 +461,8 @@ namespace Nimblist.data.Migrations
                     b.HasOne("Nimblist.Data.Models.ApplicationUser", "User")
                         .WithMany("ListShares")
                         .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade);
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
                     b.Navigation("Family");
 

--- a/src/nimblist/nimblist.data/Migrations/20250415092901_ListSharing-Constraints.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415092901_ListSharing-Constraints.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nimblist.data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ListSharingConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/src/nimblist/nimblist.data/Migrations/20250415093645_ListSharing-Constraints2.Designer.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415093645_ListSharing-Constraints2.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nimblist.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Nimblist.data.Migrations
 {
     [DbContext(typeof(NimblistContext))]
-    partial class NimblistContextModelSnapshot : ModelSnapshot
+    [Migration("20250415093645_ListSharing-Constraints2")]
+    partial class ListSharingConstraints2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/nimblist/nimblist.data/Migrations/20250415093645_ListSharing-Constraints2.cs
+++ b/src/nimblist/nimblist.data/Migrations/20250415093645_ListSharing-Constraints2.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nimblist.data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ListSharingConstraints2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "ListShares",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "FamilyId",
+                table: "ListShares",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "ListShares",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "FamilyId",
+                table: "ListShares",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/nimblist/nimblist.data/Models/ListShare.cs
+++ b/src/nimblist/nimblist.data/Models/ListShare.cs
@@ -9,11 +9,10 @@ namespace Nimblist.Data.Models
         [Key]
         public Guid Id { get; set; }
 
+        public string? UserId { get; set; } // Made nullable
 
-        public string UserId { get; set; } = string.Empty;
+        public Guid? FamilyId { get; set; } // Made nullable
 
-
-        public Guid FamilyId { get; set; }
         public Guid ListId { get; set; }
 
         [ForeignKey(nameof(UserId))]
@@ -21,10 +20,10 @@ namespace Nimblist.Data.Models
 
         [ForeignKey(nameof(FamilyId))]
         public virtual Family? Family { get; set; }
+
         [ForeignKey(nameof(ListId))]
         public virtual ShoppingList? List { get; set; }
 
-        // When the user joined the family
         public DateTimeOffset SharedAt { get; set; } = DateTimeOffset.UtcNow;
     }
 }

--- a/src/nimblist/nimblist.data/NimblistContext.cs
+++ b/src/nimblist/nimblist.data/NimblistContext.cs
@@ -95,7 +95,6 @@ namespace Nimblist.Data
                 .HasMany(f => f.ListShares)
                 .WithOne(m => m.Family)
                 .HasForeignKey(m => m.FamilyId)
-                .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
 
             // ApplicationUser to FamilyMember relationship
@@ -103,7 +102,6 @@ namespace Nimblist.Data
                 .HasMany(u => u.ListShares)
                 .WithOne(m => m.User)
                 .HasForeignKey(m => m.UserId)
-                .IsRequired()
                 .OnDelete(DeleteBehavior.Cascade);
 
             builder.Entity<ShoppingList>()


### PR DESCRIPTION
Update ListShare to allow nullable FamilyId and UserId

Changed FamilyId and UserId in ListShare to nullable types.
Updated foreign key configurations to remove IsRequired() constraints.
Created two new migration files to reflect these schema changes.
Adjusted foreign key relationships to accommodate nullable properties.