### PR TITLE
Fix CI build failures in frontend and recipescraper images

### DIFF
--- a/src/nimblist/Nimblist.Frontend/src/pages/MealPlannerPage.test.tsx
+++ b/src/nimblist/Nimblist.Frontend/src/pages/MealPlannerPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MockedFunction } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { authenticatedFetch } from "../components/HttpHelper";


### PR DESCRIPTION
## Summary

Two Docker image build failures introduced after merging #110:

**Frontend (`Nimblist.Frontend`)**
- `tsc -b` type-checks test files during the production build
- `MealPlannerPage.test.tsx` used `afterEach` as a Vitest global without an explicit import
- Fix: added `afterEach` to the import from `vitest`

**Recipe scraper (`Nimblist.recipescraper`)**
- `jstyleson==0.0.2` (transitive dep of `extruct` → `recipe-scrapers`) has never had a binary wheel — source distribution only
- `--only-binary :all:` in the Dockerfile `pip install` blocked it entirely
- Fix: removed `--only-binary :all:`; `--require-hashes` is retained so all packages are still hash-verified

## Test plan

- [ ] CI: frontend Docker image build completes without TypeScript errors
- [ ] CI: recipescraper Docker image build installs all packages successfully
- [ ] `npx tsc -b --noEmit` passes locally with no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)