### PR TITLE
Fix recipescraper Docker build: drop --only-binary from pip install

### DIFF
--- a/src/nimblist/Nimblist.recipescraper/Dockerfile
+++ b/src/nimblist/Nimblist.recipescraper/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY src/nimblist/Nimblist.recipescraper/requirements.lock .
-RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.lock
+RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 
 COPY src/nimblist/Nimblist.recipescraper/app.py .
 


### PR DESCRIPTION
jstyleson==0.0.2 (a transitive dep of extruct) has never had a binary wheel — it is source-only. --only-binary :all: therefore prevents it from being installed. Removing that flag while keeping --require-hashes preserves integrity checking without blocking pure-Python sdists.