### PR TITLE
Add OG image extraction for LLM fallback and image editing in recipe form

### DIFF
--- a/src/nimblist/Nimblist.Frontend/src/pages/RecipeDetailPage.tsx
+++ b/src/nimblist/Nimblist.Frontend/src/pages/RecipeDetailPage.tsx
@@ -28,6 +28,7 @@ const RecipeDetailPage: React.FC = () => {
   const [editDescription, setEditDescription] = useState('');
   const [editYields, setEditYields] = useState('');
   const [editTotalTime, setEditTotalTime] = useState('');
+  const [editImageUrl, setEditImageUrl] = useState('');
   const [editInstructions, setEditInstructions] = useState('');
   const [editIngredients, setEditIngredients] = useState<EditIngredient[]>([]);
   const [isSaving, setIsSaving] = useState(false);
@@ -55,6 +56,7 @@ const RecipeDetailPage: React.FC = () => {
     setEditYields(recipe.yields ?? '');
     setEditTotalTime(recipe.totalTimeMinutes != null ? String(recipe.totalTimeMinutes) : '');
     setEditInstructions(recipe.instructions ?? '');
+    setEditImageUrl(recipe.imageUrl ?? '');
     setEditIngredients(
       recipe.ingredients.length > 0
         ? recipe.ingredients.map(i => ({ text: i.text, parsedName: i.parsedName, parsedQuantity: i.parsedQuantity }))
@@ -94,7 +96,7 @@ const RecipeDetailPage: React.FC = () => {
           title: editTitle.trim(),
           description: editDescription.trim() || null,
           sourceUrl: recipe?.sourceUrl ?? null,
-          imageUrl: recipe?.imageUrl ?? null,
+          imageUrl: editImageUrl.trim() || null,
           yields: editYields.trim() || null,
           totalTimeMinutes: editTotalTime ? parseInt(editTotalTime) : null,
           instructions: editInstructions.trim() || null,
@@ -213,6 +215,38 @@ const RecipeDetailPage: React.FC = () => {
                 disabled={isSaving}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
               />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-600 mb-1">Image URL</label>
+              {editImageUrl && (
+                <img
+                  src={editImageUrl}
+                  alt="Recipe preview"
+                  className="mb-2 max-h-40 rounded-md border border-gray-200 object-cover"
+                  onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                />
+              )}
+              <div className="flex gap-2">
+                <input
+                  type="url"
+                  value={editImageUrl}
+                  onChange={e => setEditImageUrl(e.target.value)}
+                  placeholder="https://example.com/image.jpg"
+                  disabled={isSaving}
+                  className="flex-grow px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
+                />
+                {editImageUrl && (
+                  <button
+                    type="button"
+                    onClick={() => setEditImageUrl('')}
+                    disabled={isSaving}
+                    className="px-2 text-gray-400 hover:text-red-500 disabled:opacity-30 transition-colors"
+                    aria-label="Clear image"
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/nimblist/Nimblist.recipescraper/app.py
+++ b/src/nimblist/Nimblist.recipescraper/app.py
@@ -196,13 +196,24 @@ def _scraper_result(scraper):
     }
 
 
-def _llm_result(llm, scraper):
+def _extract_og_image(html: str) -> str | None:
+    """Extract og:image or twitter:image from page HTML as a fallback image source."""
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup(html, 'html.parser')
+    for selector in [{'property': 'og:image'}, {'name': 'twitter:image'}, {'name': 'twitter:image:src'}]:
+        tag = soup.find('meta', attrs=selector)
+        if tag and tag.get('content'):
+            return tag['content']
+    return None
+
+
+def _llm_result(llm, scraper, og_image: str | None = None):
     """Merge LLM-extracted data with any scraper fields available."""
     sc = scraper
     return {
         "title": llm.get('title') or (safe_call(sc.title) if sc else None) or "Untitled Recipe",
         "description": llm.get('description') or (safe_call(sc.description) if sc else None),
-        "image": safe_call(sc.image) if sc else None,
+        "image": (safe_call(sc.image) if sc else None) or og_image,
         "yields": llm.get('yields') or (safe_call(sc.yields) if sc else None),
         "total_time": llm.get('total_time') or (safe_call(sc.total_time) if sc else None),
         "ingredients": [parse_ingredient_text(str(i)) for i in (llm.get('ingredients') or [])],
@@ -234,7 +245,8 @@ def scrape():
         app.logger.info(f"Falling back to LLM extraction for {url}")
         llm = _llm_extract_recipe(resp.text)
         if llm:
-            return jsonify(_llm_result(llm, scraper))
+            og_image = _extract_og_image(resp.text)
+            return jsonify(_llm_result(llm, scraper, og_image=og_image))
         if not scraper:
             return jsonify({"error": "Could not find recipe data on this page"}), 422
 


### PR DESCRIPTION
## Summary

- **Scraper**: when the LLM fallback is used, extract `og:image` / `twitter:image` from the page HTML via BeautifulSoup (already a dependency) and use it as the recipe image when the scraper returns none
- **Frontend**: adds image editing to the `RecipeDetailPage` edit form — editable URL input, live preview thumbnail, and a clear button; the PUT request now sends the edited value instead of always preserving the original

## Test plan

- [ ] Import a recipe from a schema-less page with LLM fallback enabled — verify image is populated from OG meta tag where available
- [ ] Open an existing recipe with an image, enter edit mode — image URL should be pre-filled and the preview shown
- [ ] Change the image URL in edit mode and save — new image should appear on the detail page
- [ ] Clear the image URL and save — image should be removed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)