### PR TITLE
Fix 415 on image import: add [FromForm] and [Consumes] to endpoint

### DIFF
--- a/src/nimblist/nimblist.api/Controllers/RecipesController.cs
+++ b/src/nimblist/nimblist.api/Controllers/RecipesController.cs
@@ -83,7 +83,8 @@ namespace Nimblist.api.Controllers
 
         // POST /api/recipes/import-image  (multipart/form-data: image file)
         [HttpPost("import-image")]
-        public async Task<ActionResult<RecipeDetailDto>> ImportRecipeFromImage(IFormFile image)
+        [Consumes("multipart/form-data")]
+        public async Task<ActionResult<RecipeDetailDto>> ImportRecipeFromImage([FromForm] IFormFile image)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (string.IsNullOrEmpty(userId)) return Unauthorized();


### PR DESCRIPTION
## Summary

- Fixes a 415 Unsupported Media Type error on `POST /api/recipes/import-image`
- `[ApiController]` does not automatically bind `IFormFile` from `multipart/form-data` without an explicit `[FromForm]` attribute — without it, ASP.NET Core's content negotiation rejects the request before binding occurs
- `[Consumes("multipart/form-data")]` added alongside to explicitly declare the accepted content type

## Test plan

- [ ] Import a recipe from an image — should no longer receive a 415 error
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)