### PR TITLE
Remove [Consumes] from import-image to fix 415 in production

### DIFF
--- a/src/nimblist/nimblist.api/Controllers/RecipesController.cs
+++ b/src/nimblist/nimblist.api/Controllers/RecipesController.cs
@@ -83,7 +83,6 @@ namespace Nimblist.api.Controllers
 
         // POST /api/recipes/import-image  (multipart/form-data: image file)
         [HttpPost("import-image")]
-        [Consumes("multipart/form-data")]
         public async Task<ActionResult<RecipeDetailDto>> ImportRecipeFromImage([FromForm] IFormFile image)
         {
             var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);


### PR DESCRIPTION
## Summary

Removes `[Consumes("multipart/form-data")]` from `POST /api/recipes/import-image`. `[FromForm]` alone is sufficient to bind `IFormFile` from multipart requests — `[Consumes]` can cause a 415 in ASP.NET Core when action selection is strict about content-type negotiation.

Tested locally with Docker (Rider) — image import returns 200 with a parsed recipe.

## Test plan

- [ ] Import a recipe from an image in production — no 415
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)