### PR TITLE
Add client-side recipe search

### DIFF
--- a/src/nimblist/Nimblist.Frontend/src/pages/RecipesPage.tsx
+++ b/src/nimblist/Nimblist.Frontend/src/pages/RecipesPage.tsx
@@ -12,6 +12,7 @@ const RecipesPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [searchQuery, setSearchQuery] = useState('');
   const [mode, setMode] = useState<'import' | 'image' | 'manual'>('import');
 
   // Import from URL state
@@ -429,6 +430,17 @@ const RecipesPage: React.FC = () => {
         </form>
       )}
 
+      {/* Search */}
+      {!isLoading && !error && recipes.length > 0 && (
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="Search recipes…"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+        />
+      )}
+
       {/* List */}
       {isLoading && <p className="text-gray-500">Loading recipes…</p>}
       {error && <p className="text-red-600">{error}</p>}
@@ -436,8 +448,21 @@ const RecipesPage: React.FC = () => {
         <p className="text-gray-500">No recipes yet. Import one or create one above!</p>
       )}
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {recipes.map(recipe => (
+      {(() => {
+        const q = searchQuery.trim().toLowerCase();
+        const visible = q
+          ? recipes.filter(r =>
+              r.title.toLowerCase().includes(q) ||
+              (r.yields ?? '').toLowerCase().includes(q)
+            )
+          : recipes;
+        return (
+          <>
+            {!isLoading && !error && q && visible.length === 0 && (
+              <p className="text-gray-500">No recipes match "{searchQuery}".</p>
+            )}
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {visible.map(recipe => (
           <div key={recipe.id} className="bg-white rounded-lg shadow border border-gray-200 overflow-hidden flex flex-col">
             {recipe.imageUrl && (
               <img
@@ -470,10 +495,13 @@ const RecipesPage: React.FC = () => {
                   </button>
                 )}
               </div>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+          </>
+        );
+      })()}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Adds a search bar to the Recipes page that filters the loaded list by title and yields as the user types. No backend changes — filters client-side since personal recipe collections are small enough for instant local filtering.

- Search bar only appears once recipes are loaded
- Filters on title and yields (case-insensitive)
- Shows a "no results" message when the query matches nothing

## Test plan

- [ ] Search filters recipes in real time
- [ ] Clearing the search restores the full list
- [ ] "No recipes match" message shown for an unmatched query
- [ ] Search bar hidden when the list is empty or loading
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)